### PR TITLE
Set setdefaultencoding() to utf-8

### DIFF
--- a/resources/lib/ChannelList.py
+++ b/resources/lib/ChannelList.py
@@ -25,7 +25,8 @@ import random
 import httplib
 import base64
 
-
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 from xml.dom.minidom import parse, parseString
 


### PR DESCRIPTION
This fix issue #33 

I just add setdefaultencoding to utf-8. 
Now, python can be read playlist/channels with `Áéíóú` in name file.